### PR TITLE
Fix typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L -o syncthing.tar.gz https://github.com/syncthing/syncthing/releases/
   && rm -rf syncthing/etc \
   && rm -rf syncthing/*.pdf \
   && mkdir -p /srv/config \
-  && mkdir -p /srv/data \
+  && mkdir -p /srv/data
 
 VOLUME ["/srv/data", "/srv/config"]
 


### PR DESCRIPTION
Fixes typo in Dockerfile that makes garbage directories 

```
drwxr-xr-x  2 root      root  4096 Feb 16 17:59 VOLUME
drwxr-xr-x  3 root      root  4096 Feb 16 17:59 [
drwx------  3 syncthing users 4096 Feb 17 19:12 config
drwxr-xr-x  2 root      root  4096 Feb 16 17:59 config]
```
