### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-# ubunut 15 saves about 50MB over ubuntu stable
-FROM ubuntu:15.10
+FROM ubuntu:18.04
 MAINTAINER Joey Baker <joey@byjoeybaker.com>
 
-ENV SYNCTHING_VERSION 0.14.38
+ARG SYNCTHING_VERSION=0.14.51
+ARG GOSU_VERSION=1.10
 
-RUN apt-get update \
-  && apt-get upgrade -y --no-install-recommends \
-  && apt-get install curl ca-certificates -y --no-install-recommends \
-  && apt-get autoremove -y \
-  && apt-get clean
+ENV STNODEFAULTFOLDER=1
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install dirmngr curl ca-certificates gpg gpg-agent -y --no-install-recommends \
+  && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-  && curl -o /usr/local/bin/gosu.asc -L "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+  && curl -o /usr/local/bin/gosu.asc -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
   && gpg --verify /usr/local/bin/gosu.asc \
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
@@ -21,7 +21,7 @@ RUN gpg --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF35
 # get syncthing
 WORKDIR /srv
 RUN useradd --no-create-home -g users syncthing
-RUN curl -L -o syncthing.tar.gz https://github.com/syncthing/syncthing/releases/download/v$SYNCTHING_VERSION/syncthing-linux-amd64-v$SYNCTHING_VERSION.tar.gz \
+RUN curl -L -o syncthing.tar.gz "https://github.com/syncthing/syncthing/releases/download/v$SYNCTHING_VERSION/syncthing-linux-amd64-v$SYNCTHING_VERSION.tar.gz" \
   && tar -xzvf syncthing.tar.gz \
   && rm -f syncthing.tar.gz \
   && mv syncthing-linux-amd64-v* syncthing \
@@ -38,4 +38,3 @@ RUN chmod 770 /srv/start.sh
 ENV UID=1027
 
 ENTRYPOINT ["/srv/start.sh"]
-


### PR DESCRIPTION
- Update to Syncthing 0.14.51
- Switch to Ubuntu 18.04 base image
- Don't run apt-get upgrade/clean per Dockerfile best practices
- Install some packages and set DEBIAN_FRONTEND=noninteractive to
  decrease the amount of warnings during the build
- Use a GPG server accessible over port 80 (more firewall-friendly)
- Set STNODEFAULTFOLDER to 1 to disable automatic creation of the
  default sync folder (which causes an error due to missing
  permissions)
- Use ARG instead of ENV for variables that don't need to be
  accessed at run-time